### PR TITLE
[fix] ファイル数がWIDTHの倍数の時一列で表示される

### DIFF
--- a/05.ls/.gitignore
+++ b/05.ls/.gitignore
@@ -1,2 +1,3 @@
 ls_test/
+test/
 .ruby-version

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -30,7 +30,7 @@ def get_slice_element_count(files_text)
   files_text.map! { |file_text| file_text.multi_byte_ljust(max_string_length) }
   files_text = align_slice_count(files_text, WIDTH)
   remainder_of_zero = (files_text.size % WIDTH).zero?
-  remainder_of_zero ? 1 : files_text.size / WIDTH + 1
+  remainder_of_zero ? files_text.size / WIDTH  : files_text.size / WIDTH + 1
 end
 
 # 配列内の要素数をslice_countの値に統一する


### PR DESCRIPTION
ファイル数がWIDTHの倍数の時のみ、1列で表示されていました。
```
# 正しい出力
1     4     7
2     5     8
3     6     9

# 今までの間違っていた出力
1    2    3    4    5    6    7    8    9
```